### PR TITLE
Fix Typo in Withdrawn Event Emission

### DIFF
--- a/contracts/Staking.sol
+++ b/contracts/Staking.sol
@@ -63,7 +63,7 @@ contract Staking is ReentrancyGuard{
     require(stakedBalance[msg.sender]>=amount,"Staked amount not enough");
     totalStakedTokens=totalStakedTokens.sub(amount);
     stakedBalance[msg.sender]=stakedBalance[msg.sender].sub(amount);
-    emit Withdrawn(msg.sender, amount);(msg.sender,amount);
+    emit Withdrawn(msg.sender, amount);
     bool success = s_stakingToken.transfer(msg.sender,amount);
     require(success,"Transfer Failed");
   }


### PR DESCRIPTION
I hope this message finds you well. I came across a small typo in the `Withdrawn` event of the Staking contract. It appears that there's an extra line `(msg.sender, amount);` after emitting the event. I believe this is unintentional and may have been added by mistake.

I've removed the redundant line to ensure clarity and correctness. The corrected line is as follows:

```
emit Withdrawn(msg.sender, amount);
```

This change does not alter the logic of the contract but enhances the readability of the code. I have thoroughly tested the updated version to ensure its correctness.